### PR TITLE
Fix bug after saving-restoring a empty container with no SectionWidget.

### DIFF
--- a/AdvancedDockingSystem/src/ContainerWidget.cpp
+++ b/AdvancedDockingSystem/src/ContainerWidget.cpp
@@ -489,25 +489,28 @@ bool ContainerWidget::restoreState(const QByteArray& data)
 		int cnt = 0;
 		in >> cnt;
 
-		// Create dummy section, required to call hideSectionContent() later.
-		SectionWidget* sw = new SectionWidget(this);
-		sections.append(sw);
-
-		for (int i = 0; i < cnt; ++i)
+		if(cnt > 0)
 		{
-			QString uname;
-			in >> uname;
+			// Create dummy section, required to call hideSectionContent() later.
+			SectionWidget* sw = new SectionWidget(this);
+			sections.append(sw);
 
-			const SectionContent::RefPtr sc = SCLookupMapByName(this).value(uname);
-			if (!sc)
-				continue;
+			for (int i = 0; i < cnt; ++i)
+			{
+				QString uname;
+				in >> uname;
 
-			InternalContentData data;
-			if (!takeContent(sc, data))
-				qFatal("This should never happen!!!");
+				const SectionContent::RefPtr sc = SCLookupMapByName(this).value(uname);
+				if (!sc)
+					continue;
 
-			sw->addContent(data, false);
-			contentsToHide.append(sc);
+				InternalContentData data;
+				if (!takeContent(sc, data))
+					qFatal("This should never happen!!!");
+
+				sw->addContent(data, false);
+				contentsToHide.append(sc);
+			}
 		}
 	}
 	else if (mode == 1)

--- a/AdvancedDockingSystem/src/SectionTitleWidget.cpp
+++ b/AdvancedDockingSystem/src/SectionTitleWidget.cpp
@@ -68,6 +68,7 @@ void SectionTitleWidget::setActiveTab(bool active)
 void SectionTitleWidget::mousePressEvent(QMouseEvent* ev)
 {
 //	qDebug() << Q_FUNC_INFO << ev->pos();
+	this->grabMouse();
 	if (ev->button() == Qt::LeftButton)
 	{
 		_dragStartPos = ev->pos();
@@ -80,6 +81,8 @@ void SectionTitleWidget::mousePressEvent(QMouseEvent* ev)
 void SectionTitleWidget::mouseReleaseEvent(QMouseEvent* ev)
 {
 //	qDebug() << Q_FUNC_INFO << ev->pos();
+	if(QWidget::mouseGrabber() == this)
+		this->releaseMouse();
 	SectionWidget* section = NULL;
 
 	// Drop contents of FloatingWidget into SectionWidget.
@@ -189,7 +192,7 @@ void SectionTitleWidget::mouseMoveEvent(QMouseEvent* ev)
 	SectionWidget* section = NULL;
 
 	// Move already existing FloatingWidget
-	if (_fw)
+	if (_fw && (ev->buttons() & Qt::LeftButton))
 	{
 		const QPoint moveToPos = ev->globalPos() - (_dragStartPos + QPoint(ADS_WINDOW_FRAME_BORDER_WIDTH, ADS_WINDOW_FRAME_BORDER_WIDTH));
 		_fw->move(moveToPos);


### PR DESCRIPTION
SectionTitleWidget::mousePressEvent call 'grabMouse' to ensure the floaing widget can always follow the mouse after floated.
SectionTitleWidget::mouseMoveEvent check Qt::LeftButton.
