### PR TITLE
Function to call manually to update tab dropdown

### DIFF
--- a/AdvancedDockingSystem/include/ads/API.h
+++ b/AdvancedDockingSystem/include/ads/API.h
@@ -50,6 +50,7 @@ class QSplitter;
 ADS_NAMESPACE_BEGIN
 class ContainerWidget;
 class SectionWidget;
+class SectionContent;
 
 enum DropArea
 {

--- a/AdvancedDockingSystem/include/ads/ContainerWidget.h
+++ b/AdvancedDockingSystem/include/ads/ContainerWidget.h
@@ -99,8 +99,8 @@ public:
 	 * \see saveState()
 	 */
 	bool restoreState(const QByteArray& data);
+    
 
-	//
 	// Advanced Public API
 	// You usually should not need access to this methods
 	//
@@ -118,6 +118,9 @@ public:
 	QList<SectionContent::RefPtr> contents() const;
 
 	QPointer<DropOverlay> dropOverlay() const;
+    
+    // return section widgets to be sure to add new dock to an existing one
+    const QList<SectionWidget*>& sectionWidgets() const;
     
     void updateSectionContentTabMenus();
 

--- a/AdvancedDockingSystem/include/ads/ContainerWidget.h
+++ b/AdvancedDockingSystem/include/ads/ContainerWidget.h
@@ -118,6 +118,8 @@ public:
 	QList<SectionContent::RefPtr> contents() const;
 
 	QPointer<DropOverlay> dropOverlay() const;
+    
+    void updateSectionContentTabMenus();
 
 private:
 	//

--- a/AdvancedDockingSystem/src/ContainerWidget.cpp
+++ b/AdvancedDockingSystem/src/ContainerWidget.cpp
@@ -46,6 +46,12 @@ ContainerWidget::ContainerWidget(QWidget *parent) :
 	setLayout(_mainLayout);
 }
 
+void ContainerWidget::updateSectionContentTabMenus()
+{
+    for(auto& section : _sections)
+        section->updateTabsMenu();
+}
+
 ContainerWidget::~ContainerWidget()
 {
 	// Note: It's required to delete in 2 steps

--- a/AdvancedDockingSystem/src/ContainerWidget.cpp
+++ b/AdvancedDockingSystem/src/ContainerWidget.cpp
@@ -486,6 +486,11 @@ SectionWidget* ContainerWidget::newSectionWidget()
 	return sw;
 }
 
+const QList<SectionWidget*>& ContainerWidget::sectionWidgets() const
+{
+    return _sections;
+}
+
 SectionWidget* ContainerWidget::dropContent(const InternalContentData& data, SectionWidget* targetSection, DropArea area, bool autoActive)
 {
 	ADS_Expects(targetSection != NULL);

--- a/AdvancedDockingSystem/src/FloatingWidget.cpp
+++ b/AdvancedDockingSystem/src/FloatingWidget.cpp
@@ -33,17 +33,17 @@ FloatingWidget::FloatingWidget(ContainerWidget* container, SectionContent::RefPt
 
 	if (sc->flags().testFlag(SectionContent::Closeable))
 	{
-		QPushButton* closeButton = new QPushButton();
+		/*QPushButton* closeButton = new QPushButton();
 		closeButton->setObjectName("closeButton");
 		closeButton->setFlat(true);
 		closeButton->setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
 		closeButton->setToolTip(tr("Close"));
 		closeButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-		_titleLayout->addWidget(closeButton);
+		_titleLayout->addWidget(closeButton);*/
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-		QObject::connect(closeButton, &QPushButton::clicked, this, &FloatingWidget::onCloseButtonClicked);
+		//QObject::connect(closeButton, &QPushButton::clicked, this, &FloatingWidget::onCloseButtonClicked);
 #else
-		QObject::connect(closeButton, SIGNAL(clicked(bool)), this, SLOT(onCloseButtonClicked()));
+		//QObject::connect(closeButton, SIGNAL(clicked(bool)), this, SLOT(onCloseButtonClicked()));
 #endif
 	}
 

--- a/AdvancedDockingSystem/src/SectionTitleWidget.cpp
+++ b/AdvancedDockingSystem/src/SectionTitleWidget.cpp
@@ -25,13 +25,12 @@
 
 ADS_NAMESPACE_BEGIN
 
-SectionTitleWidget::SectionTitleWidget(SectionContent::RefPtr content, QWidget* parent) :
-	QFrame(parent),
-	_content(content),
-	_tabMoving(false),
-	_activeTab(false)
+SectionTitleWidget::SectionTitleWidget(SectionContent::RefPtr content, QWidget *parent) : QFrame(parent),
+																						  _content(content),
+																						  _tabMoving(false),
+																						  _activeTab(false)
 {
-	QBoxLayout* l = new QBoxLayout(QBoxLayout::LeftToRight);
+	QBoxLayout *l = new QBoxLayout(QBoxLayout::LeftToRight);
 	l->setContentsMargins(0, 0, 0, 0);
 	l->setSpacing(0);
 	l->addWidget(content->titleWidget());
@@ -57,28 +56,28 @@ void SectionTitleWidget::setActiveTab(bool active)
 		style()->unpolish(this);
 		style()->polish(this);
 		update();
-        
-        if(auto titleWidget = _content->titleWidget())
-        {
-            titleWidget->style()->unpolish(titleWidget);
-            titleWidget->style()->polish(titleWidget);
-            titleWidget->update();
-            
-            // also find QLabel below that and unpolish them (special titleWidget)
-            QWidget* labelChild = titleWidget->findChild<QLabel*>();
-            if(labelChild)
-            {
-                labelChild->style()->unpolish(labelChild);
-                labelChild->style()->polish(labelChild);
-                labelChild->update();
-            }
-        }
+
+		if (auto titleWidget = _content->titleWidget())
+		{
+			titleWidget->style()->unpolish(titleWidget);
+			titleWidget->style()->polish(titleWidget);
+			titleWidget->update();
+
+			// also find QLabel below that and unpolish them (special titleWidget)
+			QWidget *labelChild = titleWidget->findChild<QLabel *>();
+			if (labelChild)
+			{
+				labelChild->style()->unpolish(labelChild);
+				labelChild->style()->polish(labelChild);
+				labelChild->update();
+			}
+		}
 
 		emit activeTabChanged();
 	}
 }
 
-void SectionTitleWidget::mousePressEvent(QMouseEvent* ev)
+void SectionTitleWidget::mousePressEvent(QMouseEvent *ev)
 {
 	if (ev->button() == Qt::LeftButton)
 	{
@@ -89,15 +88,15 @@ void SectionTitleWidget::mousePressEvent(QMouseEvent* ev)
 	QFrame::mousePressEvent(ev);
 }
 
-void SectionTitleWidget::mouseReleaseEvent(QMouseEvent* ev)
+void SectionTitleWidget::mouseReleaseEvent(QMouseEvent *ev)
 {
-	SectionWidget* section = NULL;
-	ContainerWidget* cw = findParentContainerWidget(this);
+	SectionWidget *section = NULL;
+	ContainerWidget *cw = findParentContainerWidget(this);
 
 	// Drop contents of FloatingWidget into SectionWidget.
 	if (_fw)
 	{
-		SectionWidget* sw = cw->sectionAt(cw->mapFromGlobal(ev->globalPos()));
+		SectionWidget *sw = cw->sectionAt(cw->mapFromGlobal(ev->globalPosition().toPoint()));
 		if (sw)
 		{
 			cw->_dropOverlay->setAllowedAreas(ADS_NS::AllAreas);
@@ -115,24 +114,23 @@ void SectionTitleWidget::mouseReleaseEvent(QMouseEvent* ev)
 #endif
 				cw->dropContent(data, sw, loc, true);
 #else
-				QPropertyAnimation* moveAnim = new QPropertyAnimation(_fw, "pos", this);
+				QPropertyAnimation *moveAnim = new QPropertyAnimation(_fw, "pos", this);
 				moveAnim->setStartValue(_fw->pos());
 				moveAnim->setEndValue(sw->mapToGlobal(sw->rect().topLeft()));
 				moveAnim->setDuration(ADS_ANIMATION_DURATION);
 
-				QPropertyAnimation* resizeAnim = new QPropertyAnimation(_fw, "size", this);
+				QPropertyAnimation *resizeAnim = new QPropertyAnimation(_fw, "size", this);
 				resizeAnim->setStartValue(_fw->size());
 				resizeAnim->setEndValue(sw->size());
 				resizeAnim->setDuration(ADS_ANIMATION_DURATION);
 
-				QParallelAnimationGroup* animGroup = new QParallelAnimationGroup(this);
+				QParallelAnimationGroup *animGroup = new QParallelAnimationGroup(this);
 				QObject::connect(animGroup, &QPropertyAnimation::finished, [this, data, sw, loc]()
-				{
+								 {
 					InternalContentData data = _fw->takeContent();
 					_fw->deleteLater();
 					_fw.clear();
-					cw->dropContent(data, sw, loc);
-				});
+					cw->dropContent(data, sw, loc); });
 				animGroup->addAnimation(moveAnim);
 				animGroup->addAnimation(resizeAnim);
 				animGroup->start(QAbstractAnimation::DeleteWhenStopped);
@@ -143,13 +141,13 @@ void SectionTitleWidget::mouseReleaseEvent(QMouseEvent* ev)
 		else
 		{
 			DropArea dropArea = ADS_NS::InvalidDropArea;
-			if (cw->outerTopDropRect().contains(cw->mapFromGlobal(ev->globalPos())))
+			if (cw->outerTopDropRect().contains(cw->mapFromGlobal(ev->globalPosition().toPoint())))
 				dropArea = ADS_NS::TopDropArea;
-			if (cw->outerRightDropRect().contains(cw->mapFromGlobal(ev->globalPos())))
+			if (cw->outerRightDropRect().contains(cw->mapFromGlobal(ev->globalPosition().toPoint())))
 				dropArea = ADS_NS::RightDropArea;
-			if (cw->outerBottomDropRect().contains(cw->mapFromGlobal(ev->globalPos())))
+			if (cw->outerBottomDropRect().contains(cw->mapFromGlobal(ev->globalPosition().toPoint())))
 				dropArea = ADS_NS::BottomDropArea;
-			if (cw->outerLeftDropRect().contains(cw->mapFromGlobal(ev->globalPos())))
+			if (cw->outerLeftDropRect().contains(cw->mapFromGlobal(ev->globalPosition().toPoint())))
 				dropArea = ADS_NS::LeftDropArea;
 
 			if (dropArea != ADS_NS::InvalidDropArea)
@@ -170,11 +168,10 @@ void SectionTitleWidget::mouseReleaseEvent(QMouseEvent* ev)
 		}
 	}
 	// End of tab moving, change order now
-	else if (_tabMoving
-			&& (section = findParentSectionWidget(this)) != NULL)
+	else if (_tabMoving && (section = findParentSectionWidget(this)) != NULL)
 	{
 		// Find tab under mouse
-		QPoint pos = ev->globalPos();
+		QPoint pos = ev->globalPosition().toPoint();
 		pos = section->mapFromGlobal(pos);
 		const int fromIndex = section->indexOfContent(_content);
 		const int toIndex = section->indexOfContentByTitlePos(pos, this);
@@ -191,17 +188,17 @@ void SectionTitleWidget::mouseReleaseEvent(QMouseEvent* ev)
 	QFrame::mouseReleaseEvent(ev);
 }
 
-void SectionTitleWidget::mouseMoveEvent(QMouseEvent* ev)
+void SectionTitleWidget::mouseMoveEvent(QMouseEvent *ev)
 {
-	ContainerWidget* cw = findParentContainerWidget(this);
-	SectionWidget* section = NULL;
+	ContainerWidget *cw = findParentContainerWidget(this);
+	SectionWidget *section = NULL;
 
 	// Move already existing FloatingWidget
 	if (_fw && (ev->buttons() & Qt::LeftButton))
 	{
 		ev->accept();
 
-		const QPoint moveToPos = ev->globalPos() - (_dragStartPos + QPoint(ADS_WINDOW_FRAME_BORDER_WIDTH, ADS_WINDOW_FRAME_BORDER_WIDTH));
+		const QPoint moveToPos = ev->globalPosition().toPoint() - (_dragStartPos + QPoint(ADS_WINDOW_FRAME_BORDER_WIDTH, ADS_WINDOW_FRAME_BORDER_WIDTH));
 		_fw->move(moveToPos);
 
 		// Show drop indicator
@@ -244,9 +241,7 @@ void SectionTitleWidget::mouseMoveEvent(QMouseEvent* ev)
 		return;
 	}
 	// Begin to drag/float the SectionContent.
-	else if (!_fw && !_dragStartPos.isNull() && (ev->buttons() & Qt::LeftButton)
-			&& (section = findParentSectionWidget(this)) != NULL
-			&& !section->titleAreaGeometry().contains(section->mapFromGlobal(ev->globalPos())))
+	else if (!_fw && !_dragStartPos.isNull() && (ev->buttons() & Qt::LeftButton) && (section = findParentSectionWidget(this)) != NULL && !section->titleAreaGeometry().contains(section->mapFromGlobal(ev->globalPosition().toPoint())))
 	{
 		ev->accept();
 
@@ -262,7 +257,7 @@ void SectionTitleWidget::mouseMoveEvent(QMouseEvent* ev)
 		_fw->resize(section->size());
 		cw->_floatings.append(_fw); // Note: I don't like this...
 
-		const QPoint moveToPos = ev->globalPos() - (_dragStartPos + QPoint(ADS_WINDOW_FRAME_BORDER_WIDTH, ADS_WINDOW_FRAME_BORDER_WIDTH));
+		const QPoint moveToPos = ev->globalPosition().toPoint() - (_dragStartPos + QPoint(ADS_WINDOW_FRAME_BORDER_WIDTH, ADS_WINDOW_FRAME_BORDER_WIDTH));
 		_fw->move(moveToPos);
 		_fw->show();
 
@@ -276,24 +271,19 @@ void SectionTitleWidget::mouseMoveEvent(QMouseEvent* ev)
 		return;
 	}
 	// Handle movement of this tab
-	else if (_tabMoving
-			&& (section = findParentSectionWidget(this)) != NULL)
+	else if (_tabMoving && (section = findParentSectionWidget(this)) != NULL)
 	{
 		ev->accept();
 
-		int left, top, right, bottom;
-		getContentsMargins(&left, &top, &right, &bottom);
 		QPoint moveToPos = mapToParent(ev->pos()) - _dragStartPos;
-		moveToPos.setY(0/* + top*/);
+		moveToPos.setY(0 /* + top*/);
 		move(moveToPos);
 
 		return;
 	}
 	// Begin to drag title inside the title area to switch its position inside the SectionWidget.
-	else if (!_dragStartPos.isNull() && (ev->buttons() & Qt::LeftButton)
-			&& (ev->pos() - _dragStartPos).manhattanLength() >= QApplication::startDragDistance() // Wait a few pixels before start moving
-			&& (section = findParentSectionWidget(this)) != NULL
-			&& section->titleAreaGeometry().contains(section->mapFromGlobal(ev->globalPos())))
+	else if (!_dragStartPos.isNull() && (ev->buttons() & Qt::LeftButton) && (ev->pos() - _dragStartPos).manhattanLength() >= QApplication::startDragDistance() // Wait a few pixels before start moving
+			 && (section = findParentSectionWidget(this)) != NULL && section->titleAreaGeometry().contains(section->mapFromGlobal(ev->globalPosition().toPoint())))
 	{
 		ev->accept();
 

--- a/AdvancedDockingSystem/src/SectionTitleWidget.cpp
+++ b/AdvancedDockingSystem/src/SectionTitleWidget.cpp
@@ -56,6 +56,13 @@ void SectionTitleWidget::setActiveTab(bool active)
 		style()->unpolish(this);
 		style()->polish(this);
 		update();
+        
+        if(auto titleWidget = _content->titleWidget())
+        {
+            titleWidget->style()->unpolish(titleWidget);
+            titleWidget->style()->polish(titleWidget);
+            titleWidget->update();
+        }
 
 		emit activeTabChanged();
 	}

--- a/AdvancedDockingSystem/src/SectionTitleWidget.cpp
+++ b/AdvancedDockingSystem/src/SectionTitleWidget.cpp
@@ -9,6 +9,7 @@
 #include <QCursor>
 #include <QStyle>
 #include <QSplitter>
+#include <QLabel>
 
 #ifdef ADS_ANIMATIONS_ENABLED
 #include <QPropertyAnimation>
@@ -62,6 +63,15 @@ void SectionTitleWidget::setActiveTab(bool active)
             titleWidget->style()->unpolish(titleWidget);
             titleWidget->style()->polish(titleWidget);
             titleWidget->update();
+            
+            // also find QLabel below that and unpolish them (special titleWidget)
+            QWidget* labelChild = titleWidget->findChild<QLabel*>();
+            if(labelChild)
+            {
+                labelChild->style()->unpolish(labelChild);
+                labelChild->style()->polish(labelChild);
+                labelChild->update();
+            }
         }
 
 		emit activeTabChanged();

--- a/AdvancedDockingSystem/src/SectionWidget.cpp
+++ b/AdvancedDockingSystem/src/SectionWidget.cpp
@@ -73,18 +73,18 @@ SectionWidget::SectionWidget(ContainerWidget* parent) :
 #else
 	//QObject::connect(_tabsMenuButton, SIGNAL(clicked()), this, SLOT(onTabsMenuButtonClicked()));
 #endif
-
-	_closeButton = new QPushButton();
+	
+	/*_closeButton = new QPushButton();
 	_closeButton->setObjectName("closeButton");
 	_closeButton->setFlat(true);
 	_closeButton->setIcon(style()->standardIcon(QStyle::SP_TitleBarCloseButton));
 	_closeButton->setToolTip(tr("Close"));
 	_closeButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-	_topLayout->addWidget(_closeButton, 0);
+	_topLayout->addWidget(_closeButton, 0);*/
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	QObject::connect(_closeButton, &QPushButton::clicked, this, &SectionWidget::onCloseButtonClicked);
+	//QObject::connect(_closeButton, &QPushButton::clicked, this, &SectionWidget::onCloseButtonClicked);
 #else
-	QObject::connect(_closeButton, SIGNAL(clicked(bool)), this, SLOT(onCloseButtonClicked()));
+	//QObject::connect(_closeButton, SIGNAL(clicked(bool)), this, SLOT(onCloseButtonClicked()));
 #endif
 
 	_tabsLayoutInitCount = _tabsLayout->count();
@@ -349,10 +349,10 @@ void SectionWidget::setCurrentIndex(int index)
 				{
 					stw->setActiveTab(true);
 					_tabsScrollArea->ensureWidgetVisible(stw);
-					if (stw->_content->flags().testFlag(SectionContent::Closeable))
+					/*if (stw->_content->flags().testFlag(SectionContent::Closeable))
 						_closeButton->setEnabled(true);
 					else
-						_closeButton->setEnabled(false);
+						_closeButton->setEnabled(false);*/
 				}
 				else
 					stw->setActiveTab(false);


### PR DESCRIPTION
Since there are no signals/slots attached to changing a title of a tab, the dropdown that shows all tabs is not updated yet.

This commit introduces a function to manually call like described in issue #26  